### PR TITLE
feat: add license expression metadata for Aikido compliance

### DIFF
--- a/src/Bounteous.Core/Bounteous.Core.csproj
+++ b/src/Bounteous.Core/Bounteous.Core.csproj
@@ -11,6 +11,7 @@
         <TargetFramework>net10.0</TargetFramework>
         <AssemblyName>Bounteous.Core</AssemblyName>
         <RootNamespace>Bounteous.Core</RootNamespace>
+        <LicenseExpression>MIT</LicenseExpression>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Changes
- Add `<LicenseExpression>MIT</LicenseExpression>` to Bounteous.Core.csproj

## Why
- Resolve false positive Aikido license warnings
- Makes license metadata SPDX-compliant and discoverable by NuGet and compliance tools

## Example
Packages without license expressions appear as unlicensed in Aikido security scanning, flagging them as legal risks even though they are MIT-licensed open-source packages available for commercial use.